### PR TITLE
Add RetroAchievements enum

### DIFF
--- a/gaseous-signature-parser/models/RomSignatureObject.cs
+++ b/gaseous-signature-parser/models/RomSignatureObject.cs
@@ -131,7 +131,12 @@ namespace gaseous_signature_parser.models.RomSignatureObject
                     /// <summary>
                     /// https://github.com/BlitterStudio/amiberry/blob/master/whdboot/game-data/whdload_db.xml
                     /// </summary>
-                    WHDLoad = 6
+                    WHDLoad = 6,
+
+                    /// <summary>
+                    /// https://retroachievements.org
+                    /// </summary>
+                    RetroAchievements = 7
                 }
 
                 public enum RomTypes

--- a/gaseous-signature-parser/support/parsers/tosec/Country.txt
+++ b/gaseous-signature-parser/support/parsers/tosec/Country.txt
@@ -20,6 +20,7 @@ EE,Estonia
 EG,Egypt
 ES,Spain
 EU,Europe
+Europe,Europe
 FI,Finland
 FR,France
 GB,United Kingdom
@@ -68,3 +69,4 @@ USA,United States
 VN,Vietnam
 YU,Yugoslavia
 ZA,South Africa
+World,Worldwide


### PR DESCRIPTION
This is for labelling purposes only. There is no official DAT format for RetroAchievements, this just provides for services that use the enum list.