### PR TITLE
Add Unknown source type to RomSignatureObject

### DIFF
--- a/gaseous-signature-parser/models/RomSignatureObject.cs
+++ b/gaseous-signature-parser/models/RomSignatureObject.cs
@@ -227,7 +227,12 @@ namespace gaseous_signature_parser.models.RomSignatureObject
                     /// <summary>
                     /// Generic parser, used for custom parsers
                     /// </summary>
-                    Generic = 99
+                    Generic = 99,
+
+                    /// <summary>
+                    /// Unknown source type, used when the source type is not known or not specified
+                    /// </summary>
+                    Unknown = 100
                 }
 
                 public enum RomTypes


### PR DESCRIPTION
Introduce an Unknown source type to the RomSignatureObject to handle cases where the source type is not known or specified.